### PR TITLE
Update sshd.sh

### DIFF
--- a/net/sshd.sh
+++ b/net/sshd.sh
@@ -191,6 +191,8 @@ AllowAgentForwarding yes
 AllowTcpForwarding yes
 PrintMotd no
 Subsystem       sftp    /usr/lib/ssh/sftp-server
+ClientAliveInterval 30
+ClientAliveCountMax 3
 EOF"
 
 sshd_bin="sshd"


### PR DESCRIPTION
Added [ClientAliveInterval](https://man.openbsd.org/sshd_config#ClientAliveInterval). This prevents that an idle SSH/TCP connection is being closed by a Firewall/NAT/Proxy.